### PR TITLE
feat: Extract probability-modulating BFO process-disposition triples

### DIFF
--- a/abi-phases/src/phases/ontologies/relations.ttl
+++ b/abi-phases/src/phases/ontologies/relations.ttl
@@ -196,3 +196,58 @@ phases-rel:InferredLabelRelationShape rdf:type sh:NodeShape ;
     sh:minCount 1 ;
   ] ;
   rdfs:label "Inferred label relation shape"@en .
+
+#################################################################
+#    Probability-modulating dispositions
+#
+# Models claims of the form
+#   "<subject process / participant> increases (or decreases) the
+#    probability of <target process>".
+#
+# A `ProbabilityModulatingDisposition` is a BFO disposition that
+# inheres in the subject participant (an independent continuant)
+# and is realized in the subject process. It points at the target
+# process whose probability it modulates.
+#
+# The direction of modulation is captured by subclass, not by a
+# data property, so OWL reasoners can use it:
+#   - IncreaseProbabilityDisposition
+#   - DecreaseProbabilityDisposition
+#   - NoEffectProbabilityDisposition
+#################################################################
+
+phases-rel:ProbabilityModulatingDisposition rdf:type owl:Class ;
+  rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000016> ;
+  rdfs:label "probability-modulating disposition"@en ;
+  rdfs:comment "A BFO disposition borne by an independent continuant whose realization in a process modulates the probability that some other (target) process occurs."@en .
+
+phases-rel:IncreaseProbabilityDisposition rdf:type owl:Class ;
+  rdfs:subClassOf phases-rel:ProbabilityModulatingDisposition ;
+  rdfs:label "increase-probability disposition"@en ;
+  rdfs:comment "A probability-modulating disposition whose realization increases the probability that the target process occurs."@en .
+
+phases-rel:DecreaseProbabilityDisposition rdf:type owl:Class ;
+  rdfs:subClassOf phases-rel:ProbabilityModulatingDisposition ;
+  rdfs:label "decrease-probability disposition"@en ;
+  rdfs:comment "A probability-modulating disposition whose realization decreases the probability that the target process occurs."@en .
+
+phases-rel:NoEffectProbabilityDisposition rdf:type owl:Class ;
+  rdfs:subClassOf phases-rel:ProbabilityModulatingDisposition ;
+  rdfs:label "no-effect probability disposition"@en ;
+  rdfs:comment "A probability-modulating disposition whose realization has no measurable effect on the probability that the target process occurs (used to capture explicit null findings)."@en .
+
+phases-rel:disposition_target_process rdf:type owl:ObjectProperty ;
+  rdfs:domain phases-rel:ProbabilityModulatingDisposition ;
+  rdfs:range <http://purl.obolibrary.org/obo/BFO_0000015> ;
+  rdfs:label "disposition target process"@en ;
+  rdfs:comment "Relates a probability-modulating disposition to the BFO process whose probability of occurrence it modulates."@en .
+
+phases-rel:linked_to_label rdf:type owl:ObjectProperty ;
+  rdfs:range phases-label:ExtractedLabel ;
+  rdfs:label "linked to label"@en ;
+  rdfs:comment "Links a chunk-level entity (process or participant) to a canonical ExtractedLabel when the extracted text matches an existing label."@en .
+
+phases-rel:evidence_text rdf:type owl:DatatypeProperty ;
+  rdfs:range xsd:string ;
+  rdfs:label "evidence text"@en ;
+  rdfs:comment "Verbatim snippet from the source chunk supporting an extracted probability-modulating disposition."@en .

--- a/abi-phases/src/phases/orchestrations/PhasesOrchestration.py
+++ b/abi-phases/src/phases/orchestrations/PhasesOrchestration.py
@@ -23,6 +23,22 @@ from phases.workflows.ExtractedItemsEmbeddingWorkflow.ExtractedItemsEmbeddingWor
     ExtractedItemsEmbeddingWorkflowConfiguration,
     ExtractedItemsEmbeddingWorkflowParameters,
 )
+from phases.workflows.ProcessDispositionExtractionWorkflow.ProcessDispositionExtractionWorkflow import (
+    ProcessDispositionExtractionWorkflow,
+    ProcessDispositionExtractionWorkflowConfiguration,
+    ProcessDispositionExtractionWorkflowParameters,
+)
+
+PROCESS_DISPOSITION_PROMPT_PATH = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "workflows",
+        "ProcessDispositionExtractionWorkflow",
+        "prompts",
+        "probabilistic_processes.txt",
+    )
+)
 
 EXTRACTIONS_OUTPUT_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "storage", "extractions")
@@ -189,6 +205,92 @@ def run_gero_extractions_op(
         )
 
 
+class ProcessDispositionExtractionConfig(dg.Config):
+    paper_path_glob: str | None = None
+    """Non-recursive glob, relative to abi/src/phases/papers.
+
+    Examples:
+      - "solitude/*.pdf"     -> only papers directly under solitude/
+      - "gero/pmc/*.pdf"     -> only papers under gero/pmc/
+      - None                 -> all chunks in the triple store — DEFAULT
+    """
+    model: str = "gpt-5-mini"
+    chunk_limit: int | None = None
+    workers: int | None = None
+    max_relations_per_chunk: int = 8
+    link_to_labels: bool = True
+
+
+def _run_process_disposition_extraction(
+    context: dg.OpExecutionContext,
+    config: ProcessDispositionExtractionConfig,
+) -> None:
+    """Shared body used by the standalone job and the chained jobs."""
+    paths: list[str] | None = None
+    if config.paper_path_glob:
+        pattern = os.path.join(PAPERS_ROOT, config.paper_path_glob)
+        paths = sorted(glob(pattern))
+        context.log.info(
+            f"Scoping process-disposition extraction to {len(paths)} paper(s) "
+            f"matching {pattern}"
+        )
+        if not paths:
+            context.log.warning(
+                f"paper_path_glob '{config.paper_path_glob}' matched no files — "
+                "process-disposition extraction will be skipped."
+            )
+            return
+    else:
+        context.log.info(
+            "No paper_path_glob set — running over ALL chunks for "
+            "process-disposition extraction."
+        )
+
+    prompt_template = Path(PROCESS_DISPOSITION_PROMPT_PATH).read_text()
+    workflow = ProcessDispositionExtractionWorkflow(
+        ProcessDispositionExtractionWorkflowConfiguration(
+            prompt_template=prompt_template,
+            model_name=config.model,
+            max_relations_per_chunk=config.max_relations_per_chunk,
+            link_to_labels=config.link_to_labels,
+        )
+    )
+    out = Path(EXTRACTIONS_OUTPUT_DIR)
+    out.mkdir(parents=True, exist_ok=True)
+    output_path = str(out / "process_dispositions.json")
+
+    results = workflow.run(
+        ProcessDispositionExtractionWorkflowParameters(
+            paths=paths,
+            chunk_limit=config.chunk_limit,
+            workers=config.workers,
+            output_path=output_path,
+            dry_run=False,
+        )
+    )
+    total_relations = sum(len(v) for v in results.values())
+    context.log.info(
+        f"[process_dispositions] processed {len(results)} chunks, "
+        f"{total_relations} relations -> {output_path}"
+    )
+
+
+@dg.op(ins={"start": dg.In(dg.Nothing)})
+def run_process_disposition_extraction_chained_op(
+    context: dg.OpExecutionContext, config: ProcessDispositionExtractionConfig
+) -> None:
+    """Chained variant: takes a Nothing input so it can be wired after another op."""
+    _run_process_disposition_extraction(context, config)
+
+
+@dg.op
+def run_process_disposition_extraction_op(
+    context: dg.OpExecutionContext, config: ProcessDispositionExtractionConfig
+) -> None:
+    """Standalone variant: runnable on its own from the Dagster UI."""
+    _run_process_disposition_extraction(context, config)
+
+
 @dg.op(ins={"start": dg.In(dg.Nothing)})
 def embed_extracted_items_op(context: dg.OpExecutionContext) -> None:
     """Embed every ExtractedItem.extracted_text into the vector store."""
@@ -221,28 +323,45 @@ def normalize_paper_paths_job() -> None:
     name="ingest_solitude_papers",
     description=(
         "Ingest the solitude papers, run every GenericChunkExtractionWorkflow "
-        "pipeline (causes / how / when / where / effects), and embed the resulting "
-        "ExtractedItem texts so they can be searched."
+        "pipeline (causes / how / when / where / effects), embed the resulting "
+        "ExtractedItem texts, and extract probability-modulating BFO "
+        "process-disposition relations."
     ),
 )
 def ingest_solitude_papers_job() -> None:
-    embed_extracted_items_op(
+    after_embed = embed_extracted_items_op(
         start=run_solitude_extractions_op(start=ingest_solitude_papers_op())
     )
+    run_process_disposition_extraction_chained_op(start=after_embed)
 
 
 @dg.job(
     name="ingest_gero_papers",
     description=(
         "Ingest the gerotranscendence papers, run every GenericChunkExtractionWorkflow "
-        "pipeline (causes / how / when / where / effects), and embed the resulting "
-        "ExtractedItem texts so they can be searched."
+        "pipeline (causes / how / when / where / effects), embed the resulting "
+        "ExtractedItem texts, and extract probability-modulating BFO "
+        "process-disposition relations."
     ),
 )
 def ingest_gero_papers_job() -> None:
-    embed_extracted_items_op(
+    after_embed = embed_extracted_items_op(
         start=run_gero_extractions_op(start=ingest_gero_papers_op())
     )
+    run_process_disposition_extraction_chained_op(start=after_embed)
+
+
+@dg.job(
+    name="run_process_disposition_extraction",
+    description=(
+        "Extract probability-modulating BFO process-disposition relations from "
+        "every candidate chunk (or only those matching paper_path_glob). "
+        "Idempotent on (prompt_hash, model_name); already-processed chunks are "
+        "skipped."
+    ),
+)
+def run_process_disposition_extraction_job() -> None:
+    run_process_disposition_extraction_op()
 
 
 class PhasesOrchestration(DagsterOrchestration):
@@ -256,6 +375,7 @@ class PhasesOrchestration(DagsterOrchestration):
                 jobs=[
                     ingest_solitude_papers_job,
                     ingest_gero_papers_job,
+                    run_process_disposition_extraction_job,
                     normalize_paper_paths_job,
                 ],
                 sensors=[],

--- a/abi-phases/src/phases/workflows/ProcessDispositionExtractionWorkflow/ProcessDispositionExtractionWorkflow.py
+++ b/abi-phases/src/phases/workflows/ProcessDispositionExtractionWorkflow/ProcessDispositionExtractionWorkflow.py
@@ -1,0 +1,657 @@
+"""Probability-modulating process-disposition extraction workflow.
+
+Purpose
+-------
+Extract, from each document chunk, claims of the form
+
+    "<subject> increases (or decreases / has no effect on) the probability
+     that <target> happens"
+
+and persist them in BFO terms:
+
+    - A `bfo:Process` (subject_process) with a `bfo:has_participant`
+      pointing at an `bfo:IndependentContinuant` (subject_participant).
+    - A `phases-rel:ProbabilityModulatingDisposition` (one of the
+      Increase / Decrease / NoEffect subclasses) `bfo:inheres_in` the
+      participant.
+    - The subject process `bfo:realizes` that disposition.
+    - The disposition `phases-rel:disposition_target_process` points at
+      another `bfo:Process` (target_process).
+    - Every minted entity carries `phases-doc:extracted_from_chunk` and
+      `phases-doc:extracted_by` so provenance is queryable; the
+      enclosing `phases-doc:Extraction` records the prompt + model.
+    - When the participant or target text matches an existing
+      `phases-label:ExtractedLabel` (by normalized text), a
+      `phases-rel:linked_to_label` edge is added.
+
+Idempotency
+-----------
+Chunks already processed by an `Extraction` with the same
+`(prompt_hash, model_name)` are skipped, mirroring
+`GenericChunkExtractionWorkflow`.
+
+CLI
+---
+See `run_extraction.py` in this folder.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import cast
+
+from fastapi import APIRouter
+from langchain_core.messages import AIMessage
+from langchain_core.tools import BaseTool
+from langchain_openai import ChatOpenAI
+from naas_abi_core import logger
+from naas_abi_core.workflow.workflow import (
+    Workflow,
+    WorkflowConfiguration,
+    WorkflowParameters,
+)
+import rdflib
+from rdflib.term import Node
+
+from phases import ABIModule
+
+try:
+    from tqdm import tqdm
+except Exception:
+    tqdm = None
+
+
+# ---------------------------------------------------------------------------
+# Namespaces and graphs
+# ---------------------------------------------------------------------------
+
+BFO = rdflib.Namespace("http://purl.obolibrary.org/obo/")
+PHASES_DOC = rdflib.Namespace("http://purl.obolibrary.org/obo/phases/documents.owl#")
+PHASES_REL = rdflib.Namespace("http://purl.obolibrary.org/obo/phases/relations.owl#")
+PHASES_LABEL = rdflib.Namespace("http://purl.obolibrary.org/obo/phases/labels.owl#")
+
+# BFO URIs we reuse directly.
+BFO_PROCESS = BFO["BFO_0000015"]
+BFO_INDEPENDENT_CONTINUANT = BFO["BFO_0000004"]
+BFO_HAS_PARTICIPANT = BFO["BFO_0000057"]
+BFO_REALIZES = BFO["BFO_0000055"]
+BFO_INHERES_IN = BFO["BFO_0000197"]
+
+# Direction → disposition class.
+DIRECTION_TO_CLASS = {
+    "increases": PHASES_REL["IncreaseProbabilityDisposition"],
+    "decreases": PHASES_REL["DecreaseProbabilityDisposition"],
+    "no-effect": PHASES_REL["NoEffectProbabilityDisposition"],
+}
+VALID_DIRECTIONS = set(DIRECTION_TO_CLASS)
+
+PAPERS_GRAPH = rdflib.URIRef("http://ontology.naas.ai/graph/phases/papers")
+EXTRACTIONS_GRAPH = rdflib.URIRef(
+    "http://ontology.naas.ai/graph/phases/extractions"
+)
+
+
+# ---------------------------------------------------------------------------
+# Configuration / parameters
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProcessDispositionExtractionWorkflowConfiguration(WorkflowConfiguration):
+    prompt_template: str = ""  # required: must contain `{chunk_text}`
+    model_name: str = "gpt-5-mini"
+    model_timeout_seconds: int = 60
+    model_max_retries: int = 1
+    extraction_workers: int = 10
+    max_relations_per_chunk: int | None = 8
+    pipeline_name: str = "process_dispositions"
+    # When True, look up existing ExtractedLabel by normalized text and
+    # attach `linked_to_label` edges. Set False for a dry run that
+    # doesn't touch the labels graph.
+    link_to_labels: bool = True
+
+
+class ProcessDispositionExtractionWorkflowParameters(WorkflowParameters):
+    paths: list[str] | None = None
+    chunk_limit: int | None = None
+    workers: int | None = None
+    output_path: str | None = None
+    dry_run: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Workflow
+# ---------------------------------------------------------------------------
+
+
+class ProcessDispositionExtractionWorkflow(
+    Workflow[ProcessDispositionExtractionWorkflowParameters]
+):
+    module: ABIModule
+    _configuration: ProcessDispositionExtractionWorkflowConfiguration
+
+    def __init__(
+        self, configuration: ProcessDispositionExtractionWorkflowConfiguration
+    ):
+        super().__init__(configuration)
+        self._configuration = configuration
+        self.module = ABIModule.get_instance()
+        if "{chunk_text}" not in configuration.prompt_template:
+            raise ValueError(
+                "prompt_template must contain the '{chunk_text}' placeholder"
+            )
+        self._chat_model = ChatOpenAI(
+            model=configuration.model_name,
+            temperature=0,
+            timeout=configuration.model_timeout_seconds,
+            max_retries=configuration.model_max_retries,
+        )
+
+    # -- identity ------------------------------------------------------------
+
+    def _extraction_id(self) -> tuple[str, str, rdflib.URIRef]:
+        cfg = self._configuration
+        prompt_hash = hashlib.sha256(cfg.prompt_template.encode()).hexdigest()
+        extraction_id = f"{cfg.model_name}:{cfg.pipeline_name}:{prompt_hash[:16]}"
+        return (
+            extraction_id,
+            prompt_hash,
+            rdflib.URIRef(f"urn:phases:extraction:{extraction_id}"),
+        )
+
+    # -- candidate chunks ----------------------------------------------------
+
+    def _build_candidates_query(
+        self, parameters: ProcessDispositionExtractionWorkflowParameters
+    ) -> str:
+        path_clause = ""
+        if parameters.paths:
+            values = " ".join(
+                rdflib.Literal(path).n3() for path in parameters.paths
+            )
+            path_clause = f"VALUES ?path {{ {values} }}"
+
+        limit = parameters.chunk_limit
+        limit_clause = f"LIMIT {limit}" if limit is not None else ""
+
+        _, prompt_hash, _ = self._extraction_id()
+        prompt_hash_lit = rdflib.Literal(prompt_hash).n3()
+        model_name_lit = rdflib.Literal(self._configuration.model_name).n3()
+
+        return f"""PREFIX phases-doc: <http://purl.obolibrary.org/obo/phases/documents.owl#>
+
+SELECT ?chunk ?chunk_id ?text ?path WHERE {{
+    GRAPH <{PAPERS_GRAPH}> {{
+        ?chunk a phases-doc:Chunk ;
+            phases-doc:chunk_id ?chunk_id ;
+            phases-doc:text ?text ;
+            phases-doc:chunk_of ?pdf_paper_file .
+        ?pdf_paper_file phases-doc:path ?path .
+        {path_clause}
+    }}
+    # Skip chunks already processed by an Extraction with the same prompt + model.
+    FILTER NOT EXISTS {{
+        GRAPH <{EXTRACTIONS_GRAPH}> {{
+            ?prior_extraction phases-doc:prompt_hash {prompt_hash_lit} ;
+                              phases-doc:model_name {model_name_lit} .
+            ?prior_entity phases-doc:extracted_by ?prior_extraction ;
+                          phases-doc:extracted_from_chunk ?chunk .
+        }}
+    }}
+}}
+ORDER BY ?chunk_id
+{limit_clause}"""
+
+    def _load_candidate_chunks(
+        self, parameters: ProcessDispositionExtractionWorkflowParameters
+    ) -> list[tuple[Node, str, str, str]]:
+        rows = self.module.engine.services.triple_store.query(
+            self._build_candidates_query(parameters)
+        )
+        parsed: list[tuple[Node, str, str, str]] = []
+        for row in rows:
+            if isinstance(row, bool):
+                continue
+            try:
+                items = tuple(row)
+            except TypeError:
+                continue
+            if len(items) != 4:
+                continue
+            chunk, chunk_id, text, path = items
+            parsed.append(
+                (cast(Node, chunk), str(chunk_id), str(text), str(path))
+            )
+        return parsed
+
+    # -- LLM call + response parsing -----------------------------------------
+
+    def _build_prompt(self, chunk_text: str) -> str:
+        return self._configuration.prompt_template.format(chunk_text=chunk_text)
+
+    @staticmethod
+    def _normalize_phrase(text: str) -> str:
+        cleaned = re.sub(r"\s+", " ", text.strip())
+        return cleaned
+
+    def _parse_response(self, response_text: str) -> list[dict]:
+        payload: dict | None = None
+        try:
+            parsed = json.loads(response_text)
+            if isinstance(parsed, dict):
+                payload = parsed
+        except json.JSONDecodeError:
+            match = re.search(r"\{.*\}", response_text, flags=re.DOTALL)
+            if match:
+                try:
+                    parsed = json.loads(match.group(0))
+                    if isinstance(parsed, dict):
+                        payload = parsed
+                except json.JSONDecodeError:
+                    payload = None
+
+        raw_items = payload.get("relations", []) if payload else []
+        if not isinstance(raw_items, list):
+            return []
+
+        cleaned: list[dict] = []
+        seen: set[tuple[str, str, str, str]] = set()
+        for item in raw_items:
+            if not isinstance(item, dict):
+                continue
+            subject_process = self._normalize_phrase(
+                str(item.get("subject_process", ""))
+            )
+            subject_participant = self._normalize_phrase(
+                str(item.get("subject_participant", ""))
+            )
+            target_process = self._normalize_phrase(
+                str(item.get("target_process", ""))
+            )
+            direction = str(item.get("direction", "")).strip().lower()
+            evidence_text = self._normalize_phrase(
+                str(item.get("evidence_text", ""))
+            )
+
+            if not (subject_process and subject_participant and target_process):
+                continue
+            if direction not in VALID_DIRECTIONS:
+                continue
+
+            key = (
+                subject_process.lower(),
+                subject_participant.lower(),
+                target_process.lower(),
+                direction,
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            cleaned.append(
+                {
+                    "subject_process": subject_process,
+                    "subject_participant": subject_participant,
+                    "target_process": target_process,
+                    "direction": direction,
+                    "evidence_text": evidence_text,
+                }
+            )
+
+        max_n = self._configuration.max_relations_per_chunk
+        if max_n is not None:
+            cleaned = cleaned[:max_n]
+        return cleaned
+
+    def _extract(self, chunk_text: str) -> list[dict]:
+        prompt = self._build_prompt(chunk_text)
+        response: AIMessage = cast(AIMessage, self._chat_model.invoke(prompt))
+        content = response.content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, str):
+                    parts.append(item)
+                elif isinstance(item, dict) and isinstance(item.get("text"), str):
+                    parts.append(item["text"])
+            response_text = "\n".join(parts)
+        else:
+            response_text = str(content)
+        return self._parse_response(response_text)
+
+    def _extract_for_chunk(
+        self, chunk: tuple[Node, str, str, str]
+    ) -> tuple[str, str, list[dict], str | None]:
+        _, chunk_id, text, path = chunk
+        try:
+            return chunk_id, path, self._extract(text), None
+        except Exception as exc:
+            return chunk_id, path, [], str(exc)
+
+    # -- run -----------------------------------------------------------------
+
+    def run(
+        self, parameters: ProcessDispositionExtractionWorkflowParameters
+    ) -> dict[str, list[dict]]:
+        chunks = self._load_candidate_chunks(parameters)
+        logger.debug(
+            f"ProcessDispositionExtraction candidate chunks: {len(chunks)}"
+        )
+
+        if parameters.dry_run:
+            if not chunks:
+                print(
+                    "[ProcessDispositionExtraction][dry-run] No candidate chunks.",
+                    flush=True,
+                )
+                return {}
+            chunk_id, path, items, error = self._extract_for_chunk(chunks[0])
+            print(f"[dry-run] Chunk ID: {chunk_id}", flush=True)
+            print(f"[dry-run] Source path: {path}", flush=True)
+            if error:
+                print(f"[dry-run] Error: {error}", flush=True)
+            else:
+                print(f"[dry-run] {len(items)} relations extracted:", flush=True)
+                for i, it in enumerate(items, 1):
+                    print(
+                        f"  {i}. ({it['direction']}) "
+                        f"{it['subject_process']} "
+                        f"[participant: {it['subject_participant']}] "
+                        f"-> {it['target_process']}",
+                        flush=True,
+                    )
+            return {chunk_id: items}
+
+        workers = parameters.workers or self._configuration.extraction_workers
+        workers = max(1, workers)
+
+        results: dict[str, list[dict]] = {}
+        if workers > 1:
+            with ThreadPoolExecutor(max_workers=workers) as executor:
+                futures = [
+                    executor.submit(self._extract_for_chunk, c) for c in chunks
+                ]
+                completion = as_completed(futures)
+                if tqdm is not None:
+                    completion = tqdm(
+                        completion,
+                        total=len(futures),
+                        desc="Extracting",
+                        unit="chunk",
+                    )
+                for future in completion:
+                    chunk_id, path, items, error = future.result()
+                    if error:
+                        logger.error(f"Chunk {chunk_id} ({path}) failed: {error}")
+                        continue
+                    results[chunk_id] = items
+        else:
+            chunk_iter = chunks
+            if tqdm is not None:
+                chunk_iter = tqdm(chunks, desc="Extracting", unit="chunk")
+            for chunk in chunk_iter:
+                chunk_id, path, items, error = self._extract_for_chunk(chunk)
+                if error:
+                    logger.error(f"Chunk {chunk_id} ({path}) failed: {error}")
+                    continue
+                results[chunk_id] = items
+
+        if parameters.output_path:
+            Path(parameters.output_path).write_text(json.dumps(results, indent=2))
+            logger.debug(f"Wrote results to {parameters.output_path}")
+
+        self._persist_to_triple_store(results)
+        return results
+
+    # -- persistence ---------------------------------------------------------
+
+    def _persist_to_triple_store(self, results: dict[str, list[dict]]) -> None:
+        if not results:
+            return
+
+        cfg = self._configuration
+        extraction_id, prompt_hash, extraction_uri = self._extraction_id()
+
+        graph = rdflib.Graph()
+
+        # Extraction provenance.
+        graph.add((extraction_uri, rdflib.RDF.type, PHASES_DOC.Extraction))
+        graph.add(
+            (extraction_uri, PHASES_DOC.extraction_id, rdflib.Literal(extraction_id))
+        )
+        graph.add(
+            (
+                extraction_uri,
+                PHASES_DOC.pipeline_name,
+                rdflib.Literal(cfg.pipeline_name),
+            )
+        )
+        graph.add(
+            (
+                extraction_uri,
+                PHASES_DOC.prompt_template,
+                rdflib.Literal(cfg.prompt_template),
+            )
+        )
+        graph.add(
+            (extraction_uri, PHASES_DOC.prompt_hash, rdflib.Literal(prompt_hash))
+        )
+        graph.add(
+            (extraction_uri, PHASES_DOC.model_name, rdflib.Literal(cfg.model_name))
+        )
+
+        chunk_uri_by_id = self._resolve_chunk_uris(list(results.keys()))
+
+        # Resolve label canonicals only once across all extracted phrases.
+        label_lookup: dict[str, rdflib.URIRef] = {}
+        if cfg.link_to_labels:
+            phrases: set[str] = set()
+            for items in results.values():
+                for it in items:
+                    phrases.add(it["subject_participant"].lower())
+                    phrases.add(it["target_process"].lower())
+            label_lookup = self._resolve_label_uris(phrases)
+
+        for chunk_id, items in results.items():
+            chunk_uri = chunk_uri_by_id.get(chunk_id)
+            if chunk_uri is None:
+                logger.warning(
+                    f"No Chunk URI found for chunk_id {chunk_id}; skipping its relations."
+                )
+                continue
+            for i, item in enumerate(items):
+                self._emit_relation(
+                    graph,
+                    extraction_id=extraction_id,
+                    extraction_uri=extraction_uri,
+                    chunk_id=chunk_id,
+                    chunk_uri=chunk_uri,
+                    index=i,
+                    item=item,
+                    label_lookup=label_lookup,
+                )
+
+        total_relations = sum(len(v) for v in results.values())
+        logger.debug(
+            f"Inserting process-disposition extraction graph: "
+            f"1 Extraction + {total_relations} relation(s)"
+        )
+        self.module.engine.services.triple_store.insert(
+            graph, graph_name=EXTRACTIONS_GRAPH
+        )
+
+    def _emit_relation(
+        self,
+        graph: rdflib.Graph,
+        *,
+        extraction_id: str,
+        extraction_uri: rdflib.URIRef,
+        chunk_id: str,
+        chunk_uri: rdflib.URIRef,
+        index: int,
+        item: dict,
+        label_lookup: dict[str, rdflib.URIRef],
+    ) -> None:
+        """Emit the BFO subgraph for one extracted probability-modulating claim."""
+
+        direction = item["direction"]
+        disp_class = DIRECTION_TO_CLASS[direction]
+
+        subj_proc = item["subject_process"]
+        subj_part = item["subject_participant"]
+        tgt_proc = item["target_process"]
+        evidence = item.get("evidence_text") or ""
+
+        # Stable, idempotent URIs for the four entities. The hash keys on
+        # (extraction_id, chunk_id, role, normalized text) so a rerun with
+        # the same prompt/model on the same chunk produces the same URIs.
+        def mint(role: str, text: str) -> rdflib.URIRef:
+            digest = hashlib.sha256(
+                f"{extraction_id}:{chunk_id}:{index}:{role}:{text.lower()}".encode()
+            ).hexdigest()
+            return rdflib.URIRef(f"urn:phases:proc_disp:{role}:{digest}")
+
+        subj_proc_uri = mint("subject_process", subj_proc)
+        subj_part_uri = mint("subject_participant", subj_part)
+        disp_uri = mint(f"disposition:{direction}", f"{subj_part}|{tgt_proc}")
+        tgt_proc_uri = mint("target_process", tgt_proc)
+
+        # Subject process (bfo:Process).
+        graph.add((subj_proc_uri, rdflib.RDF.type, BFO_PROCESS))
+        graph.add((subj_proc_uri, rdflib.RDFS.label, rdflib.Literal(subj_proc)))
+        graph.add((subj_proc_uri, BFO_HAS_PARTICIPANT, subj_part_uri))
+        graph.add((subj_proc_uri, BFO_REALIZES, disp_uri))
+        self._attach_provenance(
+            graph, subj_proc_uri, chunk_uri, extraction_uri, evidence
+        )
+
+        # Subject participant (bfo:IndependentContinuant).
+        graph.add(
+            (subj_part_uri, rdflib.RDF.type, BFO_INDEPENDENT_CONTINUANT)
+        )
+        graph.add((subj_part_uri, rdflib.RDFS.label, rdflib.Literal(subj_part)))
+        self._attach_provenance(
+            graph, subj_part_uri, chunk_uri, extraction_uri, evidence=None
+        )
+
+        # Disposition (one of the three subclasses).
+        graph.add((disp_uri, rdflib.RDF.type, disp_class))
+        graph.add(
+            (
+                disp_uri,
+                rdflib.RDFS.label,
+                rdflib.Literal(f"{direction} probability of {tgt_proc}"),
+            )
+        )
+        graph.add((disp_uri, BFO_INHERES_IN, subj_part_uri))
+        graph.add(
+            (disp_uri, PHASES_REL.disposition_target_process, tgt_proc_uri)
+        )
+        self._attach_provenance(
+            graph, disp_uri, chunk_uri, extraction_uri, evidence=None
+        )
+
+        # Target process (bfo:Process).
+        graph.add((tgt_proc_uri, rdflib.RDF.type, BFO_PROCESS))
+        graph.add((tgt_proc_uri, rdflib.RDFS.label, rdflib.Literal(tgt_proc)))
+        self._attach_provenance(
+            graph, tgt_proc_uri, chunk_uri, extraction_uri, evidence=None
+        )
+
+        # Optional label-canonicalisation edges.
+        participant_label = label_lookup.get(subj_part.lower())
+        if participant_label is not None:
+            graph.add((subj_part_uri, PHASES_REL.linked_to_label, participant_label))
+        target_label = label_lookup.get(tgt_proc.lower())
+        if target_label is not None:
+            graph.add((tgt_proc_uri, PHASES_REL.linked_to_label, target_label))
+
+    @staticmethod
+    def _attach_provenance(
+        graph: rdflib.Graph,
+        entity_uri: rdflib.URIRef,
+        chunk_uri: rdflib.URIRef,
+        extraction_uri: rdflib.URIRef,
+        evidence: str | None,
+    ) -> None:
+        graph.add((entity_uri, PHASES_DOC.extracted_from_chunk, chunk_uri))
+        graph.add((entity_uri, PHASES_DOC.extracted_by, extraction_uri))
+        if evidence:
+            graph.add(
+                (entity_uri, PHASES_REL.evidence_text, rdflib.Literal(evidence))
+            )
+
+    # -- helpers -------------------------------------------------------------
+
+    def _resolve_chunk_uris(self, chunk_ids: list[str]) -> dict[str, rdflib.URIRef]:
+        if not chunk_ids:
+            return {}
+        values = " ".join(rdflib.Literal(cid).n3() for cid in chunk_ids)
+        query = f"""PREFIX phases-doc: <http://purl.obolibrary.org/obo/phases/documents.owl#>
+SELECT ?chunk ?chunk_id WHERE {{
+    GRAPH <{PAPERS_GRAPH}> {{
+        ?chunk a phases-doc:Chunk ; phases-doc:chunk_id ?chunk_id .
+        VALUES ?chunk_id {{ {values} }}
+    }}
+}}"""
+        rows = self.module.engine.services.triple_store.query(query)
+        return {
+            str(chunk_id): cast(rdflib.URIRef, chunk) for chunk, chunk_id in rows
+        }
+
+    def _resolve_label_uris(
+        self, normalized_phrases: set[str]
+    ) -> dict[str, rdflib.URIRef]:
+        """Map lower-cased phrase → ExtractedLabel URI when present.
+
+        Matches by case-insensitive equality of `phases-label:label_text`.
+        """
+        if not normalized_phrases:
+            return {}
+        values = " ".join(
+            rdflib.Literal(p).n3() for p in normalized_phrases
+        )
+        query = f"""PREFIX phases-label: <http://purl.obolibrary.org/obo/phases/labels.owl#>
+SELECT ?label ?label_text_lc WHERE {{
+    ?label a phases-label:ExtractedLabel ;
+           phases-label:label_text ?label_text .
+    BIND(LCASE(STR(?label_text)) AS ?label_text_lc)
+    VALUES ?label_text_lc {{ {values} }}
+}}"""
+        try:
+            rows = self.module.engine.services.triple_store.query(query)
+        except Exception as exc:
+            logger.warning(f"Label lookup failed; skipping label linking: {exc}")
+            return {}
+
+        lookup: dict[str, rdflib.URIRef] = {}
+        for row in rows:
+            if isinstance(row, bool):
+                continue
+            try:
+                label_uri, label_text_lc = tuple(row)
+            except (TypeError, ValueError):
+                continue
+            lookup.setdefault(str(label_text_lc), cast(rdflib.URIRef, label_uri))
+        return lookup
+
+    # -- adapters required by the Workflow ABC -------------------------------
+
+    def as_tools(self) -> list[BaseTool]:
+        return []
+
+    def as_api(
+        self,
+        router: APIRouter,
+        route_name: str = "",
+        name: str = "",
+        description: str = "",
+        description_stream: str = "",
+        tags: list[str | Enum] | None = [],
+    ) -> None:
+        return None

--- a/abi-phases/src/phases/workflows/ProcessDispositionExtractionWorkflow/prompts/probabilistic_processes.txt
+++ b/abi-phases/src/phases/workflows/ProcessDispositionExtractionWorkflow/prompts/probabilistic_processes.txt
@@ -1,0 +1,65 @@
+You are extracting PROBABILITY-MODULATING CLAIMS from a research text and
+rephrasing them in BFO process form.
+
+Goal: capture claims of the form
+
+    "<subject> increases (or decreases, or has no effect on) the probability
+     that <target> happens".
+
+The output is consumed by an ontology where both endpoints must be BFO
+processes (occurrents — things that unfold in time) and the subject process
+must have an explicit independent-continuant participant that bears the
+probability-modulating disposition.
+
+What to extract
+- Only claims where the text asserts (or strongly implies) a directional
+  influence of one thing on the probability of another thing happening.
+- Each claim becomes ONE JSON object with these fields:
+
+    {
+      "subject_process":    "<verb-phrase / -ing nominal>",
+      "subject_participant": "<noun phrase: the bearer of the disposition>",
+      "target_process":     "<verb-phrase / -ing nominal>",
+      "direction":          "increases" | "decreases" | "no-effect",
+      "evidence_text":      "<short verbatim quote from the text>"
+    }
+
+Hard requirements on shape
+- `subject_process` and `target_process` MUST be processes — phrased as a
+  verb phrase or -ing nominal that names something that unfolds in time.
+  Examples (good): "sugar consumption", "social isolation", "regular
+  meditation practice", "occurrence of headache", "onset of depression".
+  Examples (bad — fix them): "sugar"  -> "sugar consumption";
+                              "headache" -> "occurrence of headache";
+                              "loneliness" -> "experiencing loneliness".
+- `subject_participant` MUST be a noun phrase naming the independent
+  continuant that participates in the subject process and bears the
+  disposition. It is what the disposition "lives in".
+  Example: subject_process="sugar consumption" -> subject_participant="sugar".
+           subject_process="regular meditation practice" ->
+                                       subject_participant="meditation practitioner".
+- `direction` MUST be exactly one of: "increases", "decreases", "no-effect".
+  Use "no-effect" ONLY when the text explicitly asserts a null finding
+  (e.g. "X had no significant effect on Y").
+- `evidence_text` MUST be a short verbatim quote (<= 200 characters) from
+  the text supporting the claim. Do not paraphrase here.
+
+Hard requirements on content
+- Do NOT invent claims that are not supported by the text.
+- Do NOT extract claims about the study itself (e.g. "the authors find...").
+  State the claim as a general proposition about the world.
+- If the direction is uncertain or hedged so heavily that you cannot pick
+  one of the three options, DROP the claim entirely.
+- Use the most specific phrasing the text supports.
+- Output 0 to 8 claims. If the text contains no such claim, return an
+  empty list.
+
+Return strict JSON only in this exact shape:
+{{"relations": [
+   {{"subject_process": "...", "subject_participant": "...",
+     "target_process": "...", "direction": "increases",
+     "evidence_text": "..."}}
+]}}
+
+Text:
+{chunk_text}

--- a/abi-phases/src/phases/workflows/ProcessDispositionExtractionWorkflow/run_extraction.py
+++ b/abi-phases/src/phases/workflows/ProcessDispositionExtractionWorkflow/run_extraction.py
@@ -1,0 +1,135 @@
+"""Click CLI for ProcessDispositionExtractionWorkflow.
+
+Examples
+--------
+Dry run (first candidate chunk, no writes):
+    uv run abi run script abi_phases/phases/workflows/ProcessDispositionExtractionWorkflow/run_extraction.py run --dry-run
+
+Run over a limited set of chunks and dump JSON:
+    uv run abi run script abi_phases/phases/workflows/ProcessDispositionExtractionWorkflow/run_extraction.py run \
+        --chunk-limit 20 --output ./out/process_dispositions.json
+
+Restrict to specific paper paths (repeatable):
+    uv run abi run script abi_phases/phases/workflows/ProcessDispositionExtractionWorkflow/run_extraction.py run \
+        --path ".../paper1.pdf" --path ".../paper2.pdf"
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from phases.workflows.ProcessDispositionExtractionWorkflow.ProcessDispositionExtractionWorkflow import (
+    ProcessDispositionExtractionWorkflow,
+    ProcessDispositionExtractionWorkflowConfiguration,
+    ProcessDispositionExtractionWorkflowParameters,
+)
+
+PROMPTS_DIR = Path(__file__).parent / "prompts"
+DEFAULT_PROMPT = PROMPTS_DIR / "probabilistic_processes.txt"
+
+
+@click.group()
+def cli() -> None:
+    """Extract probability-modulating BFO process-disposition relations."""
+
+
+@cli.command("run")
+@click.option(
+    "--prompt-file",
+    type=click.Path(exists=True, dir_okay=False),
+    default=str(DEFAULT_PROMPT),
+    show_default=True,
+    help="Prompt template (must contain {chunk_text}).",
+)
+@click.option(
+    "--path",
+    "paths",
+    multiple=True,
+    help="Restrict to chunks from this paper path (repeatable).",
+)
+@click.option(
+    "--chunk-limit",
+    type=int,
+    default=None,
+    help="Max number of chunks to process.",
+)
+@click.option(
+    "--workers",
+    type=int,
+    default=None,
+    help="Parallel LLM workers.",
+)
+@click.option(
+    "--model",
+    type=str,
+    default="gpt-5-mini",
+    show_default=True,
+    help="LLM model name.",
+)
+@click.option(
+    "--max-relations",
+    type=int,
+    default=8,
+    show_default=True,
+    help="Max relations kept per chunk.",
+)
+@click.option(
+    "--no-label-linking",
+    is_flag=True,
+    default=False,
+    help="Skip looking up canonical ExtractedLabel matches.",
+)
+@click.option(
+    "--output",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help="Write {chunk_id: [relations]} JSON to this path.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Process only the first candidate chunk, print result, do not persist.",
+)
+def run_cmd(
+    prompt_file: str,
+    paths: tuple[str, ...],
+    chunk_limit: int | None,
+    workers: int | None,
+    model: str,
+    max_relations: int,
+    no_label_linking: bool,
+    output: str | None,
+    dry_run: bool,
+) -> None:
+    """Run the probability-modulating disposition extraction."""
+    prompt_template = Path(prompt_file).read_text()
+
+    workflow = ProcessDispositionExtractionWorkflow(
+        ProcessDispositionExtractionWorkflowConfiguration(
+            prompt_template=prompt_template,
+            model_name=model,
+            max_relations_per_chunk=max_relations,
+            link_to_labels=not no_label_linking,
+        )
+    )
+    results = workflow.run(
+        ProcessDispositionExtractionWorkflowParameters(
+            paths=list(paths) or None,
+            chunk_limit=chunk_limit,
+            workers=workers,
+            output_path=output,
+            dry_run=dry_run,
+        )
+    )
+    total = sum(len(v) for v in results.values())
+    click.echo(
+        f"processed {len(results)} chunks, {total} relations"
+        + (f" -> {output}" if output else "")
+    )
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary

Adds a new chunk-extraction pipeline that captures claims of the form
*"X increases (or decreases, or has no effect on) the probability that Y happens"* and persists them as a proper BFO subgraph rather than as free-text strings.

Example — *"sugar increases the probability of headache"* becomes:

```
:proc_sugar_consumption  a bfo:Process ;
    bfo:has_participant   :ic_sugar ;
    bfo:realizes          :disp_xyz ;
    phases-doc:extracted_from_chunk :chunk_42 .

:disp_xyz  a phases-rel:IncreaseProbabilityDisposition ;
    bfo:inheres_in        :ic_sugar ;
    phases-rel:disposition_target_process :proc_headache .

:proc_headache  a bfo:Process .
```

Direction is encoded by **class** (Increase / Decrease / NoEffect subclasses of `ProbabilityModulatingDisposition`), not by a data property, so OWL reasoners can use it.

## What changed

### Ontology — `abi-phases/src/phases/ontologies/relations.ttl`
- New class `phases-rel:ProbabilityModulatingDisposition` (subclass of `bfo:Disposition`) with three subclasses:
  - `IncreaseProbabilityDisposition`
  - `DecreaseProbabilityDisposition`
  - `NoEffectProbabilityDisposition`
- New properties:
  - `phases-rel:disposition_target_process` — disposition → target `bfo:Process`
  - `phases-rel:linked_to_label` — entity → canonical `phases-label:ExtractedLabel`
  - `phases-rel:evidence_text` — verbatim quote
- Pydantic `relations.py` is regenerated automatically by `onto2py` at module load (see `phases/__init__.py`).

### Workflow — `abi-phases/src/phases/workflows/ProcessDispositionExtractionWorkflow/`
- `ProcessDispositionExtractionWorkflow.py` — mirrors the `GenericChunkExtractionWorkflow` lifecycle: SPARQL candidate-chunk query with an idempotent `(prompt_hash, model_name)` skip-clause, parallel LLM calls, hand-built rdflib subgraph per extracted claim.
- `prompts/probabilistic_processes.txt` — forces `-ing` / verb-phrase nominals for both `subject_process` and `target_process`, a noun-phrase `subject_participant` (the disposition's bearer), and a strict `direction ∈ {increases, decreases, no-effect}`. Claims with uncertain direction are dropped.
- Optional canonical label linking by case-insensitive `phases-label:label_text` match.
- `run_extraction.py` — Click CLI with `--dry-run`, `--chunk-limit`, `--path`, `--workers`, `--no-label-linking`, `--output`.

### Dagster — `abi-phases/src/phases/orchestrations/PhasesOrchestration.py`
- New standalone job `run_process_disposition_extraction` (config: `paper_path_glob`, `model`, `chunk_limit`, `workers`, `max_relations_per_chunk`, `link_to_labels`).
- New chained op `run_process_disposition_extraction_chained_op` added to the existing `ingest_solitude_papers` and `ingest_gero_papers` jobs after `embed_extracted_items_op`.

## Why

The existing axiom / generic extraction pipelines store claims as free-text strings (`ExtractedItem.extracted_text`). They're easy to search but the structure isn't queryable in BFO terms. This new pipeline keeps the proven extraction machinery (chunk fan-out, idempotent skip-clause, provenance triples) but emits a structured BFO subgraph instead, so downstream reasoners and SPARQL queries can work with processes and dispositions directly.

## Test plan

- [ ] Trigger `run_process_disposition_extraction` from the Dagster UI with `chunk_limit: 5` and `paper_path_glob: solitude/*.pdf`.
- [ ] Inspect `storage/extractions/process_dispositions.json` — confirm each entry has `subject_process` and `target_process` in verb-phrase form, a noun `subject_participant`, and `direction ∈ {increases, decreases, no-effect}`.
- [ ] SPARQL the extractions graph for `?d a phases-rel:IncreaseProbabilityDisposition` and confirm the four-entity subgraph (subject process, participant, disposition, target process) is fully connected with the right BFO relations.
- [ ] Re-run with the same config — confirm the SPARQL skip-clause keeps chunk count at 0 (idempotency check).
- [ ] Run `ingest_solitude_papers` end-to-end and confirm the new op fires after `embed_extracted_items_op`.

## Reviewer notes

- `relations.py` is auto-generated; the diff only shows the TTL change. The first `phases` module load after merge will regenerate the Pydantic side via `onto2py`.
- Persistence hand-builds the rdflib graph (matching `GenericChunkExtractionWorkflow._persist_to_triple_store`) rather than going through Pydantic, because the new model emits four distinct entity types per claim and gluing that together via the generated Pydantic classes added more friction than value.
- Dagster needs two op variants (`run_process_disposition_extraction_op` and `_chained_op`) because the same op can't be used both with and without a `Nothing` input across different graphs.